### PR TITLE
fix: detect `zsh` vs. `{ba,}sh` in `env.sh`

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 
 # load dependencies:
-shell_ext=$(ps -p $$ -ocomm= | sed 's;^bash$;sh;')
+shell_ext=$(ps -p $$ -ocomm= | sed -e 's;^.*\.;;g' -e 's;^bash$;sh;')
 setup=/group/clas12/packages/setup.$shell_ext
 if [ -e $setup ]
 then

--- a/env.sh
+++ b/env.sh
@@ -1,12 +1,14 @@
 
 # load dependencies:
-if [ -e /group/clas12/packages/setup.sh ]
+shell_ext=$(ps -p $$ -ocomm= | sed 's;^bash$;sh;')
+setup=/group/clas12/packages/setup.$shell_ext
+if [ -e $setup ]
 then
-    source /group/clas12/packages/setup.sh
+    source $setup
     module purge
     module load clas12
 else
-    echo WARNING:  Cannot find RCDB installation.
+    echo "WARNING:  Cannot find CLAS12 modules setup file $setup"
 fi
 
 # put clas12-workflow/lib in $PYTHONPATH


### PR DESCRIPTION
There is a difference in the setup files for different shells, surprisingly between `zsh` and `sh/bash`:
```
/group/clas12/packages/setup.sh   # for {,ba}sh
/group/clas12/packages/setup.zsh  # for zsh
```
If running `zsh` you source `setup.sh`, you'll get errors.

This PR causes `env.sh` to detect which shell is being used to source the appropriate `setup.*sh` file.
